### PR TITLE
Regnet support

### DIFF
--- a/p2p.py
+++ b/p2p.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     parser.add_argument('config', default="config.json", nargs="?", help='config file')
     parser.add_argument('to', default="", nargs="?", help='to')
     parser.add_argument('value', default=0, nargs="?", help='amount')
-    parser.add_argument('-n', '--network', default='mainnet', help='Specify maintnet or testnet')
+    parser.add_argument('-n', '--network', default='mainnet', help='Specify mainnet, testnet or regnet')
     parser.add_argument('-c', '--cores', default=multiprocessing.cpu_count(), help='Specify number of cores to use')
     parser.add_argument('-p', '--pool', default='', help='Specify pool to use')
     parser.add_argument('-d', '--debug', default=False, help='Debug messages')

--- a/yadacoin/endpoints.py
+++ b/yadacoin/endpoints.py
@@ -716,7 +716,7 @@ class BlockchainSocketServer(Namespace):
             print "block is bad"
             raise e
         try:
-            if regnet not in config.network:
+            if 'regnet' not in config.network:
                 requests.post(
                     'https://yadacoin.io/peers',
                     json.dumps({

--- a/yadacoin/endpoints.py
+++ b/yadacoin/endpoints.py
@@ -716,16 +716,17 @@ class BlockchainSocketServer(Namespace):
             print "block is bad"
             raise e
         try:
-            requests.post(
-                'https://yadacoin.io/peers',
-                json.dumps({
-                    'host': config.peer_host,
-                    'port': config.peer_port
-                }),
-                headers={
-                    "Content-Type": "application/json"
-                }
-            )
+            if regnet not in config.network:
+                requests.post(
+                    'https://yadacoin.io/peers',
+                    json.dumps({
+                        'host': config.peer_host,
+                        'port': config.peer_port
+                    }),
+                    headers={
+                        "Content-Type": "application/json"
+                    }
+                )
         except:
             print 'ERROR: failed to get peers, exiting...'
 

--- a/yadacoin/miningpool.py
+++ b/yadacoin/miningpool.py
@@ -26,6 +26,8 @@ class MiningPool(object):
             self.max_block_time = 600
         elif self.config.network == 'testnet':
             self.max_block_time = 10
+        elif self.config.network == 'regnet':
+            self.max_block_time = 0
 
         self.max_target = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 

--- a/yadacoin/peers.py
+++ b/yadacoin/peers.py
@@ -29,6 +29,16 @@ class Peers(object):
 
     @classmethod
     def init(cls, config, mongo, network='mainnet', my_peer=True):
+        if network == 'regnet':
+            # Insert ourself to have at least one peer. Not sure this is required, but allows for more tests coverage.
+            cls.peers.append(
+                    Peer(
+                        config, mongo,
+                        config.serve_host, config.serve_port,
+                        peer.get('bulletin_secret')
+                    )
+                )
+            return
         if network == 'mainnet':
             url = 'https://yadacoin.io/peers'
         elif network == 'testnet':
@@ -94,6 +104,8 @@ class Peer(object):
 
     def report(self):
         try:
+            if self.config.network == 'regnet':
+                return
             if self.config.network == 'mainnet':
                 url = 'https://yadacoin.io/peers'
             elif self.config.network == 'testnet':
@@ -154,6 +166,8 @@ class Peer(object):
     
     @classmethod
     def save_my_peer(cls, config, mongo, network):
+        if self.config.network == 'regnet':
+            return
         peer = config.peer_host + ":" + str(config.peer_port)
         mongo.db.config.update({'mypeer': {"$ne": ""}}, {'mypeer': peer}, upsert=True)
         if network == 'mainnet':


### PR DESCRIPTION
Experimental support for a Regtest mode.

- Does not connect to peers from centralized list
- Only use itself as peer
- Does not advert itself nor report bad peer to the central api, not to spam it.
- No time limit on blocks, so we can mine instantly at low diff, regtest mode only.

Future improvements:
- add a node command, in regnet mode only, "generate N" to mine N blocks with rewards to self.