### PR TITLE
Network, pool and miner hashrate upgrade

### DIFF
--- a/plugins/yadacoinpool/templates/pool-stats.html
+++ b/plugins/yadacoinpool/templates/pool-stats.html
@@ -33,6 +33,10 @@
             <h2>Network</h2>
             <h4 style="font-weight: bold;">Hash rate</h4 style="font-weight: bold;">
             <div id="network-hash-rate"></div>
+            <div id="network-hash-rate_khps"></div>
+            <div id="network-hash-rate_mhps"></div>
+            <h4 style="font-weight: bold;">Network Difficulty</h4 style="font-weight: bold;">
+            <div id="network-difficulty"></div>
             <h4 style="font-weight: bold;">Height</h4 style="font-weight: bold;">
             <div id="network-height"></div>
             <h4 style="font-weight: bold;">Reward</h4 style="font-weight: bold;">
@@ -83,7 +87,8 @@
                 $('#pool-blocks-found').html(data.pool.blocks_found);
                 $('#pool-min-payout').html(data.pool.min_payout);
                 $('#pool-url').html(data.pool.url);
-
+                
+                $('#network-difficulty').html(data.network.difficulty);
                 $('#network-height').html(data.network.height);
                 $('#network-reward').html(data.network.reward);
                 var newDate = new Date();
@@ -91,6 +96,8 @@
                 dateString = newDate.toUTCString();
                 $('#network-last-block').html(dateString);
                 $('#network-hash-rate').html(data.network.hashes_per_second.toFixed(0) + 'H/s');
+                $('#network-hash-rate_khps').html(data.network.hashes_per_second_khps.toFixed(2) + 'KH/s');
+                $('#network-hash-rate_mhps').html(data.network.hashes_per_second_mhps.toFixed(2) + 'MH/s');
 
                 $('#market-last-btc').html(data.market.last_btc);
             })

--- a/yadacoin/http/pool.py
+++ b/yadacoin/http/pool.py
@@ -66,7 +66,7 @@ class PoolHashRateHandler(BaseHandler):
         last_share = await self.config.mongo.async_db.shares.find_one(query, {'_id': 0}, sort=[('time', -1)])
         if not last_share:
             return self.render_as_json({'result': 0})
-        miner_hashrate_seconds = self.config.miner_hashrate_seconds if hasattr(self.config, 'miner_hashrate_seconds') else 600
+        miner_hashrate_seconds = self.config.miner_hashrate_seconds if hasattr(self.config, 'miner_hashrate_seconds') else 1200
 
         query = {'time': { '$gt': last_share['time'] - miner_hashrate_seconds}}
         if '.' in address:
@@ -80,10 +80,10 @@ class PoolHashRateHandler(BaseHandler):
                     'address_only': address
                 },
             ]
+        miner_diff = int(0x10000000000000001) // int(self.config.pool_target3, 16)
         number_of_shares = await self.config.mongo.async_db.shares.count_documents(query)
-        miner_hashrate = (number_of_shares * 69905) / miner_hashrate_seconds
+        miner_hashrate = (number_of_shares * miner_diff) / miner_hashrate_seconds
         self.render_as_json({'miner_hashrate': int(miner_hashrate)})
-
 
 class PoolScanMissedPayoutsHandler(BaseHandler):
     async def get(self):


### PR DESCRIPTION
Diffrent way to calculate network hashrate, based on https://wiki.bitcoinsv.io/index.php/Difficulty and https://bitcoin.stackexchange.com/questions/11139/how-is-the-network-hash-rate-calculated

Because MAX TAGET in YadaCoin is different than in Bitcoin, I recalculated the required values

For Bitcoin we have D*2**48 / 0xffff / 600 at MAX Target 0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
For yada we have D*2**48 / 0x100000000 / 600 at MAX Taget 0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

Fixed hashrate calculation for pool and miner after changing pool_target
Added hashrate value in KH/s and MH/s to pool page and current network difficulty