### PR TITLE
fix sharp drop in difficulty after 20m+ block

### DIFF
--- a/yadacoin/core/chain.py
+++ b/yadacoin/core/chain.py
@@ -244,7 +244,7 @@ class CHAIN(object):
             latest_target = last_block.target
             delta = max_target - latest_target
             # Linear decrease to reach max target after one hour block time.
-            new_target = int(latest_target + delta * current_block_time / 3600)
+            new_target = int((latest_target + delta) * current_block_time / 3600)
             # print("adjust", current_block_time, MinerSimulator.HEX(new_target), latest_target)
             adjusted = new_target
             # To be used later on, once the rest is calc'd

--- a/yadacoin/core/chain.py
+++ b/yadacoin/core/chain.py
@@ -243,7 +243,7 @@ class CHAIN(object):
         if current_block_time > 2 * target_time:
             current_target = block.target
             # Linear decrease to reach max target after one hour block time.
-            new_target = int(current_target + current_target * (current_block_time - 600) / 600)
+            new_target = int(current_target + current_target * (current_block_time - target_time) / current_block_time)
             # print("adjust", current_block_time, MinerSimulator.HEX(new_target), latest_target)
             adjusted = new_target
             # To be used later on, once the rest is calc'd

--- a/yadacoin/core/chain.py
+++ b/yadacoin/core/chain.py
@@ -107,7 +107,7 @@ class CHAIN(object):
             special_target = int(target * (target_factor * 4))
         elif int(block_height) >= cls.FORK_10_MIN_BLOCK:
             special_target = int(target) # we handle the adjustment in get_target now.
-        elif int(block_height) >= cls.POW_FORK_V3:
+        elif int(block_height) >= cls.POW_FORK_V3 and int(block_height) < cls.FORK_10_MIN_BLOCK:
             # from 60k, POW_FORK_V3, we aim to reach MAX_TARGET_V3 after MAX_TARGET_AFTER_V3
             if delta_t >= 2 * cls.MAX_TARGET_AFTER_V3:
                 # but after twice that time, if still stuck - hard block - allow anything (MAX_TARGET)
@@ -241,10 +241,9 @@ class CHAIN(object):
         current_block_time = int(block.time) - int(last_block.time)
         adjusted = False
         if current_block_time > 2 * target_time:
-            latest_target = last_block.target
-            delta = max_target - latest_target
+            current_target = block.target
             # Linear decrease to reach max target after one hour block time.
-            new_target = int((latest_target + delta) * current_block_time / 3600)
+            new_target = int(current_target + current_target * (current_block_time - 600) / 600)
             # print("adjust", current_block_time, MinerSimulator.HEX(new_target), latest_target)
             adjusted = new_target
             # To be used later on, once the rest is calc'd


### PR DESCRIPTION
tested on local forked node, test passed
before that, the difficulty dropped to practically 1 after block longer than 20m
![Zrzut ekranu z 2023-02-16 21-36-14](https://user-images.githubusercontent.com/67603180/219489568-e2fca664-c853-4768-bf42-386a68b95302.png)
![Zrzut ekranu z 2023-02-16 21-57-50](https://user-images.githubusercontent.com/67603180/219489589-6543fc52-b11c-46da-af7c-2df35bbabdc5.png)
block time = 1685
difficulty decreased from 112 to 78