### PR TITLE
disable "1h+ block" reset difficulty function

### DIFF
--- a/yadacoin/core/chain.py
+++ b/yadacoin/core/chain.py
@@ -278,7 +278,7 @@ class CHAIN(object):
         )  # 1 hour and 30 min at 10 min per block - Faster reaction to drops in blocktime, we want to make "instamine" harder
         target_time = 10 * 60  # 10 min
         # That should not happen
-        if int(block.time) - int(last_block.time) > 3600:
+        if int(block.time) - int(last_block.time) > 3600 and block.index <= 446400:
             cls.config.app_log.debug("Block time over max. Max target set.")
             return int(max_target)
         # decrease after 2x target - can be 3 as well


### PR DESCRIPTION
As you can see the network difficulty issue still exists, in my humble opinion you should consider disabling this feature from your code. It is the cause of such synchronization problems. It is enough that one of the pools with a large hashrate falls out of synchronization or simply crashes, then the overall network hashrate drops sharply and extends the time in which we find a block, after one hour the difficulty is reset to 1. 
It is enough that we have a function that after a block longer than 20 minutes will reduce the difficulty in proportion to the time in which the previous block was found. 
Please, Matt, consider this option because this function has caused and will cause only problems. I don't know if this form is enough to effectively disable it, possibly improve it or create something of your own :)
![Zrzut ekranu z 2023-07-23 20-41-02](https://github.com/pdxwebdev/yadacoin/assets/67603180/4fe8f105-4586-4c8c-be5e-54f89987236a)
