### PR TITLE
Yadacoin pool page v2

### DIFF
--- a/plugins/yadacoinpool/handlers.py
+++ b/plugins/yadacoinpool/handlers.py
@@ -165,6 +165,7 @@ class PoolInfoHandler(BaseWebHandler):
                     "version": ".".join([str(x) for x in version]),
                 },
                 "pool": {
+                    "pool_address": self.config.address,
                     "hashes_per_second": pool_hash_rate,
                     "miner_count": miner_count_pool_stat["value"],
                     "worker_count": worker_count_pool_stat["value"],
@@ -182,7 +183,7 @@ class PoolInfoHandler(BaseWebHandler):
                     ],
                     "blocks_found": total_blocks_found,
                     "fee": self.config.pool_take,
-                    "payout_frequency": self.config.payout_frequency,
+                    "payout_frequency": self.config.pool_payer_wait,
                     "payouts": payouts,
                     "blocks": pool_blocks_found_list[:100],
                     "pool_perecentage": pool_perecentage,

--- a/plugins/yadacoinpool/templates/pool-stats.html
+++ b/plugins/yadacoinpool/templates/pool-stats.html
@@ -55,7 +55,8 @@
     <div class="column">
       <div class="box">
         <h5><b>BLOCK REAWORD</b></h5>
-        <div><span  id="network-reward"></span> YDA</div>
+        <h4><div>MINERS: <b><span  id="miners-reward"></span></b></div></h4>
+        <h4><div>MASTER NODES: <b><span  id="master-nodes-reward"></span></b></div></h4>
       </div>
     </div>
     <div class="column">
@@ -74,7 +75,7 @@
       <div class="box">
         <h5><b>MINIMUM PAYOUT</b></h5>
         <div id="pool-min-payout"></div>
-        <h6 id="pool-payout-frequency"></h6>
+        <h5 id="pool-payout-frequency"></h5>
       </div>
     </div>
     <div class="column">
@@ -94,7 +95,7 @@
         <h5><b><center>HOW TO START</center></b></h5>
         <div>Create wallet</div>
         <div>Download XMRigCC</div>
-        <div>XMRigCC conf.json settings:</div>
+        <div>XMRigCC config.json settings:</div>
         <h5>"algo": "rx/yada",</h5>
         <h5>"url": "<span id="pool-url">"</span>",</h5>
         <h5>"user": "Your wallet address.Worker ID",</h5>
@@ -110,7 +111,7 @@
         </center>
       <h2>POOL BLOCKS</h2>
       <table id="blocks-table" class="table">
-        <tr><th>Time Found</th><th>Height</th><th>Reward</th><th>Block Hash</th></tr> <!- TODO: I tried to get a reward from "pool-blocks" but if a block has more than one transaction, strange values came out ->
+        <tr><th>Time Found</th><th>Height</th><th>Reward</th><th>Block Hash</th></tr>
       </table>
       <center><button class="button" role="button"><a href="#" id="loadMore">Load More Blocks</a></button></center>
       <h2>MINER STATISTICS</h2>
@@ -118,131 +119,309 @@
         <input type="text" name="address" id="address" placeholder="address" style="width: 75%; height: 35px; float:left;" />
         <button class="button">Get stats</button>
       </form>
-      <h4>MINER HASH RATE: <b><span id="hash-rate"></span></b></h4>
-      <h4>TOTAL HASHES SUBMITTED: <b><span id="total-hash"></span></b></h4>
-      <table id="payouts-table" class="table">
-        <tr><th>Time Sent</th><th>TXN ID</th><th>Amount</th></tr>
-      </table>
-      <center><button class="button" role="button"><a href="#" id="loadMore">Load More Payments</a></button></center>
- <!- TODO: dont know how to activate this function on Payouts Table ->
+          <div class="column2">
+              <table id="miner-stats-table" class="table"></table>
+          </div>
+          <div class="column2">
+              <div id="miner-pay-container"></div>
+          </div>
+      <div id="payouts-table-container">
+        <table id="payouts-table" class="table">
+        </table>
+      </div>
+      <div id="pagination-container">
+        <ul id="pagination" class="pagination"></ul>
+      </div>
     </div>
 </body>
 
 <script type="text/javascript">
-        $(document).ready(function() {
-            $.get('/pool-info').then((data) => {
-                if(data.pool.hashes_per_second < 1000) {
-                    $('#pool-hash-rate').html(data.pool.hashes_per_second + ' H/sec ');
-                }
-                else if(data.pool.hashes_per_second >= 1000 && data.pool.hashes_per_second < 1000000) {
-                    $('#pool-hash-rate').html((data.pool.hashes_per_second / 1000).toFixed(2) + ' KH/sec ');
-                }
-                else if(data.pool.hashes_per_second >= 1000000) {
-                    $('#pool-hash-rate').html((data.pool.hashes_per_second / 1000000).toFixed(2) + ' MH/sec ');
-                }
-                if(data.pool.blocks.length > 0) {
-                    var newDate = new Date();
-                    newDate.setTime(data.pool.blocks[0].time*1000);
-                    dateString = newDate.toLocaleString();
-                    $('#pool-last-block').html(data.pool.blocks[0].index);
-                    $('#pool-last-block-time').html(dateString);
-                }
-                $('#pool-miner-count').html(data.pool.miner_count);
-                $('#pool-worker-count').html(data.pool.worker_count);
-                $('#pool-payout-scheme').html(data.pool.payout_scheme);
-                $('#pool-fee').html(data.pool.pool_fee * 100 + '%');
-                $('#pool-blocks-found').html(data.pool.blocks_found);
-                $('#pool-min-payout').html(data.pool.min_payout + ' YDA');
-                $('#pool-url').html(data.pool.url);
-                $('#pool-perecentage').html('(' + data.pool.pool_perecentage.toFixed(2) + ' %)');
-                $('#pool-avg-block-time').html(data.pool.avg_block_time);
-                $('#pool-payout-frequency').html('After every ' + data.pool.payout_frequency + ' BLOCK found by pool');
-                if(data.pool.payout_frequency > 1) {
-                    $('#pool-payout-frequency').html('After every ' + data.pool.payout_frequency + ' BLOCKS found by pool');
-                }
-                $('#network-difficulty').html(data.network.difficulty.toFixed(3));
-                $('#network-height').html(data.network.height);
-                $('#network-reward').html(data.network.reward);
+    function formatHashRate(hashrate) {
+        let unit = 'H/s';
+
+        if (hashrate >= 1000000) {
+            hashrate /= 1000000;
+            unit = 'MH/s';
+        } else if (hashrate >= 1000) {
+            hashrate /= 1000;
+            unit = 'KH/s';
+        }
+
+        return hashrate.toFixed(2) + ' ' + unit;
+    }
+
+    $(document).ready(function () {
+        $.get('/pool-info').then((data) => {
+            $('#pool-hash-rate').html(formatHashRate(data.pool.hashes_per_second));
+            if (data.pool.blocks.length > 0) {
                 var newDate = new Date();
-                newDate.setTime(data.network.last_block*1000);
+                newDate.setTime(data.pool.blocks[0].time * 1000);
                 dateString = newDate.toLocaleString();
-                $('#network-last-block').html(dateString);
-                if(data.network.avg_hashes_per_second < 1000) {
-                    $('#avg-network-hash-rate').html(data.network.avg_hashes_per_second.toFixed(0) + ' H/sec');
-                }
-                else if(data.network.avg_hashes_per_second >= 1000 && data.network.avg_hashes_per_second < 1000000) {
-                    $('#avg-network-hash-rate').html((data.network.avg_hashes_per_second / 1000).toFixed(2) + ' KH/sec');
-                }
-                else if(data.network.avg_hashes_per_second >= 1000000) {
-                    $('#avg-network-hash-rate').html((data.network.avg_hashes_per_second / 1000000).toFixed(2) + ' MH/sec');
-                }
-                if(data.network.current_hashes_per_second < 1000) {
-                    $('#current-network-hash-rate').html(data.network.current_hashes_per_second.toFixed(0) + ' H/sec');
-                }
-                else if(data.network.current_hashes_per_second >= 1000 && data.network.current_hashes_per_second < 1000000) {
-                    $('#current-network-hash-rate').html((data.network.current_hashes_per_second / 1000).toFixed(2) + ' KH/sec');
-                }
-                else if(data.network.current_hashes_per_second >= 1000000) {
-                    $('#current-network-hash-rate').html((data.network.current_hashes_per_second / 1000000).toFixed(2) + ' MH/sec');
-                }
-                $('#market-last-btc').html(data.market.last_btc.toFixed(8));
-                $('#market-last-usdt').html(data.market.last_usdt.toFixed(8));
+                $('#pool-last-block').html(data.pool.blocks[0].index);
+                $('#pool-last-block-time').html(dateString);
+            }
+            $('#pool-miner-count').html(data.pool.miner_count);
+            $('#pool-worker-count').html(data.pool.worker_count);
+            $('#pool-payout-scheme').html(data.pool.payout_scheme);
+            $('#pool-fee').html((data.pool.pool_fee * 100).toFixed(2) + '%');
+            $('#pool-blocks-found').html(data.pool.blocks_found);
+            $('#pool-min-payout').html(data.pool.min_payout + ' YDA');
+            $('#pool-url').html(data.pool.url);
+            $('#pool-perecentage').html('(' + data.pool.pool_perecentage.toFixed(2) + ' %)');
+            $('#pool-avg-block-time').html(data.pool.avg_block_time);
+            $('#network-difficulty').html(data.network.difficulty.toFixed(3));
+            $('#network-height').html(data.network.height);
+            var blockReward = parseFloat(data.network.reward);
+            var MinersReward = (90 / 100) * blockReward;
+            var NodesReward = (10 / 100) * blockReward;
+            $('#miners-reward').html(MinersReward.toFixed(2) + ' YDA');
+            $('#master-nodes-reward').html(NodesReward.toFixed(2) + ' YDA');
+            var newDate = new Date();
+            newDate.setTime(data.network.last_block * 1000);
+            dateString = newDate.toLocaleString();
+            $('#network-last-block').html(dateString);
+            $('#avg-network-hash-rate').html(formatHashRate(data.network.avg_hashes_per_second));
+            $('#current-network-hash-rate').html(formatHashRate(data.network.current_hashes_per_second));
 
-                if(data.pool.blocks.length === 0) return $('#blocks-table').html('<tr><th>Time Found</th><th>Height</th><th>Reward</th><th>Block Hash</th></tr>');
-                    for(var i=0; i < data.pool.blocks.length; i++) {
-                        var newDate = new Date();
-                        newDate.setTime(data.pool.blocks[i].time*1000);
-                        dateString = newDate.toLocaleString();
-                        $('#blocks-table').append('<tr><td>' + dateString + '</td><td>' + data.pool.blocks[i].index + '</a></td><td>N/a</td><td><a target="_blank" href="https://yadacoin.io/explorer?term=' + data.pool.blocks[i].hash + '">' + data.pool.blocks[i].hash + '</td></tr>');
-                    }
-                    var pagelength = 5;
-                    var pageIndex = 1;
-                    var selector = "tr:gt(" + pagelength + ")";
-                    $(selector).hide();
+            function formatTime(seconds) {
+              const minutes = Math.floor(seconds / 60);
+              const hours = Math.floor(minutes / 60);
 
-                    $("#loadMore").click(function(){
-                        var itemsCount = ((pageIndex * pagelength) + pagelength);
-                        var selector = "tr:lt(" + itemsCount + ")";
-                    $(selector).show();
-                    pageIndex++;
-                    });
-            })
-            $('#form').submit(function(e) {
-                e.preventDefault();
-                $.get('/payouts-for-address?address=' + $('#address').val()).then((data) => {
-                    if(data.results.length === 0) return $('#payouts-table').html('<tr>><th>Time Sent</th><th>TXN ID</th><th>Amount</th></tr>');
-                    $('#payouts-table').html('');
-                    $('#payouts-table').append('<tr><th>Time Sent</th><th>TXN ID</th><th>Amount</th></tr>');
-                    for(var i=0; i < data.results.length; i++) {
-                        var selectOutput = {};
-                        var newDate = new Date();
-                        newDate.setTime(data.results[i]['txn'].time*1000);
-                        dateString = newDate.toLocaleString();
-                        for(var j=0; j < data.results[i]['txn'].outputs.length; j++) {
-                            if(data.results[i]['txn'].outputs[j].to === $('#address').val()) {
-                                selectOutput = data.results[i]['txn'].outputs[j];
+              if (hours > 0) {
+                return hours + ' hour(s)';
+              } else if (minutes > 0) {
+                return minutes + ' minute(s)';
+              } else {
+                return seconds + ' second(s)';
+              }
+            }
+
+            const payoutFrequency = data.pool.payout_frequency;
+            const formattedFrequency = formatTime(payoutFrequency);
+            $('#pool-payout-frequency').html('Payout every: ' + formattedFrequency);
+
+            if(data.pool.blocks.length === 0) return $('#blocks-table').html('<tr><th>Time Found</th><th>Height</th><th>Reward</th><th>Block Hash</th></tr>');
+                for(var i=0; i < data.pool.blocks.length; i++) {
+                    var newDate = new Date();
+                    newDate.setTime(data.pool.blocks[i].time*1000);
+                    dateString = newDate.toLocaleString();
+                    var reward = getRewardFromOutputs(data.pool.blocks[i].transactions);
+                    $('#blocks-table').append('<tr><td>' + dateString + '</td><td>' + data.pool.blocks[i].index + '</a></td><td>' + reward + '</td><td><a target="_blank" href="https://yadacoin.io/explorer?term=' + data.pool.blocks[i].hash + '">' + data.pool.blocks[i].hash + '</td></tr>');
+                }
+                function getRewardFromOutputs(transactions) {
+                    var highestReward = 0.0;
+                    
+                    for (var i = 0; i < transactions.length; i++) {
+                        for (var j = 0; j < transactions[i].outputs.length; j++) {
+                            if (transactions[i].outputs[j].to === data.pool.pool_address) {
+                                var currentReward = transactions[i].outputs[j].value;
+                                if (currentReward > highestReward) {
+                                    highestReward = currentReward;
+                                }
                             }
                         }
-                    $('#payouts-table').append('<tr><td>' + dateString + '<td><a target="_blank" href="https://yadacoin.io/explorer?term=' + data.results[i]['txn'].id + '">' + data.results[i]['txn'].id + '</a></td><td>' + parseFloat(selectOutput.value).toFixed(8) + ' YDA' + '</td></tr>');
                     }
+                    return highestReward + ' YDA';
+                }
+                var pagelength = 5;
+                var pageIndex = 1;
+                var selector = "tr:gt(" + pagelength + ")";
+                $(selector).hide();
+
+                $("#loadMore").click(function(){
+                    var itemsCount = ((pageIndex * pagelength) + pagelength);
+                    var selector = "tr:lt(" + itemsCount + ")";
+                $(selector).show();
+                pageIndex++;
                 });
-                $.get('/shares-for-address?address=' + $('#address').val()).then((data) => {
-                    $('#total-hash').html(data.total_hash)
-                });
-                $.get('/hashrate-for-address?address=' + $('#address').val()).then((data) => {
-                    if(data.miner_hashrate < 1000) {
-                        $('#hash-rate').html(data.miner_hashrate + ' H/s');
-                    }
-                    else if(data.miner_hashrate >= 1000 && data.miner_hashrate < 1000000) {
-                        $('#hash-rate').html((data.miner_hashrate / 1000).toFixed(2) + ' KH/s');
-                    }
-                    else if(data.miner_hashrate >= 1000000) {
-                        $('#hash-rate').html((data.miner_hashrate / 1000000).toFixed(2) + ' MH/s');
-                    }
+        });
+
+        $('#form').submit(function (e) {
+            e.preventDefault();
+
+            let last24hPaid = 0;
+            let last7DaysPaid = 0;
+            let totalPaid = 0;
+
+            $.get('/pool-info').then((data) => {
+                const marketLastBTC = data.market.last_btc;
+                const marketLastUSDT = data.market.last_usdt;
+                $.get('/payouts-for-address?address=' + $('#address').val()).then((data) => {
+                    createMinerPayTable(data, marketLastBTC, marketLastUSDT);
                 });
             });
+
+            $.get('/miner-stats-for-address?address=' + $('#address').val()).then((data) => {
+              createMinerStatsTable(data);
+            });
+
+            $.get('/payouts-for-address?address=' + $('#address').val()).then((data) => {
+              var currentPage = 1;
+              createPayoutsTable(data, currentPage);
+            });
         });
+
+        function createPayoutsTable(data, currentPage) {
+          var itemsPerPage = 10;
+          var startIndex = (currentPage - 1) * itemsPerPage;
+          var endIndex = startIndex + itemsPerPage;
+
+          if (data.results.length === 0) {
+            $('#payouts-table').html('<tr><th>Time Sent</th><th>For Block</th><th>TXN ID</th><th>Amount</th></tr>');
+          } else {
+            $('#payouts-table').html('');
+            $('#payouts-table').append('<tr><th>Time Sent</th><th>For Block</th><th>TXN ID</th><th>Amount</th></tr>');
+
+            for (var i = startIndex; i < data.results.length && i < endIndex; i++) {
+              var selectOutput = {};
+              var newDate = new Date();
+              newDate.setTime(data.results[i]['txn'].time * 1000);
+              dateString = newDate.toLocaleString();
+
+              var blockIndex = Array.isArray(data.results[i].index) ? data.results[i].index.join(', ') : data.results[i].index;
+
+              for (var j = 0; j < data.results[i]['txn'].outputs.length; j++) {
+                if (data.results[i]['txn'].outputs[j].to === $('#address').val()) {
+                  selectOutput = data.results[i]['txn'].outputs[j];
+                }
+              }
+
+              $('#payouts-table').append('<tr><td>' + dateString + '</td><td>' + blockIndex + '</td><td><a target="_blank" href="https://yadacoin.io/explorer?term=' + data.results[i]['txn'].id + '">' + data.results[i]['txn'].id + '</a></td><td>' + parseFloat(selectOutput.value).toFixed(8) + ' YDA' + '</td></tr>');
+            }
+          }
+
+          var totalPages = Math.ceil(data.results.length / itemsPerPage);
+          var maxVisiblePages = 10;
+          var pagination = $('#pagination').html('');
+          var startPage = 1;
+
+          if (currentPage > maxVisiblePages / 2) {
+            startPage = currentPage - Math.floor(maxVisiblePages / 2);
+          }
+
+          var endPage = startPage + maxVisiblePages - 1;
+          if (endPage > totalPages) {
+            endPage = totalPages;
+            startPage = endPage - maxVisiblePages + 1;
+            if (startPage < 1) {
+              startPage = 1;
+            }
+          }
+
+          for (var page = startPage; page <= endPage; page++) {
+            var pageLink = $('<a class="page-link" href="#">' + page + '</a>');
+            var pageItem = $('<li class="page-item"></li>').append(pageLink);
+            if (page === currentPage) {
+              pageItem.addClass('active');
+            }
+
+            pagination.append(pageItem);
+          }
+
+          $('#pagination li').on('click', function () {
+            currentPage = parseInt($(this).text());
+            createPayoutsTable(data, currentPage);
+            $('html, body').animate({
+              scrollTop: $('#payouts-table-container').offset().top
+            }, 'slow');
+          });
+        }
+
+        function createMinerStatsTable(data) {
+          if (data.miner_stats.length === 0) {
+            return $('#miner-stats-table').html('<tr><th>Worker Name</th><th>Hashrate</th><th>Shares</th><th>Hashes</th><th>Status</th></tr>');
+          }
+
+          $('#miner-stats-table').html('');
+          $('#miner-stats-table').append('<tr><th>Worker Name</th><th>Hashrate</th><th>Shares</th><th>Hashes</th><th>Status</th></tr>');
+
+          for (var i = 0; i < data.miner_stats.length; i++) {
+            var workerName = data.miner_stats[i].worker_name;
+            var hashrate = formatHashRate(data.miner_stats[i].worker_hashrate);
+            var shares = data.miner_stats[i].worker_share;
+            var hashes = data.miner_stats[i].worker_hash;
+            var status = data.miner_stats[i].status;
+            var statusClass = status === "Online" ? "online-status" : "offline-status";
+
+            var row = '<tr><td>' + workerName + '</td><td>' + hashrate + '</td><td>' + shares + '</td><td>' + hashes + '</td><td class="' + statusClass + '">' + status + '</td></tr>';
+            $('#miner-stats-table').append(row);
+          }
+
+          var totalHashrate = formatHashRate(data.total_hashrate);
+          var totalShares = data.total_share;
+          var totalHashes = data.total_hash;
+
+          var totalRow = '<tr><td><b>Total:</b></td><td>' + totalHashrate + '</td><td>' + totalShares + '</td><td>' + totalHashes + '</td><td></td></tr>';
+          $('#miner-stats-table').append(totalRow);
+        }
+
+        function createMinerPayTable(data, marketLastBTC, marketLastUSDT) {
+
+            let last24hPaid = 0;
+            let last7DaysPaid = 0;
+            let totalPaid = 0;
+
+            if (data.results.length > 0) {
+
+                const now = new Date();
+                const last24hDate = new Date(now - 24 * 60 * 60 * 1000);
+                const last7DaysDate = new Date(now - 7 * 24 * 60 * 60 * 1000);
+
+                for (let i = 0; i < data.results.length; i++) {
+                    const payoutDate = new Date(data.results[i]['txn'].time * 1000);
+                    const payoutAmount = parseFloat(data.results[i]['txn'].outputs[0].value);
+
+                    if (payoutDate >= last24hDate) {
+                        last24hPaid += payoutAmount;
+                    }
+
+                    if (payoutDate >= last7DaysDate) {
+                        last7DaysPaid += payoutAmount;
+                    }
+
+                    totalPaid += payoutAmount;
+                }
+            }
+
+            const tableHTML = `
+                <table id="miner-pay" class="table">
+                    <thead>
+                        <tr>
+                            <th>Time Period</th>
+                            <th>Paid</th>
+                            <th>Value USDT</th>
+                            <th>Value BTC</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Last 24h</td>
+                            <td id="last-24h-paid-value">${last24hPaid.toFixed(8)} YDA</td>
+                            <td id="last-24h-usdt">${(last24hPaid * marketLastUSDT).toFixed(8)} USD</td>
+                            <td id="last-24h-btc">${(last24hPaid * marketLastBTC).toFixed(8)} BTC</td>
+                        </tr>
+                        <tr>
+                            <td>Last Week</td>
+                            <td id="last-7-days-paid-value">${last7DaysPaid.toFixed(8)} YDA</td>
+                            <td id="last-7-days-usdt">${(last7DaysPaid * marketLastUSDT).toFixed(8)} USD</td>
+                            <td id="last-7-days-btc">${(last7DaysPaid * marketLastBTC).toFixed(8)} BTC</td>
+                        </tr>
+                        <tr>
+                            <td>Total</td>
+                            <td id="total-paid-value">${totalPaid.toFixed(8)} YDA</td>
+                            <td id="total-usdt">${(totalPaid * marketLastUSDT).toFixed(8)} USD</td>
+                            <td id="total-btc">${(totalPaid * marketLastBTC).toFixed(8)} BTC</td>
+                        </tr>
+                    </tbody>
+                </table>
+            `;
+
+            $('#miner-pay-container').html(tableHTML);
+        }
+
+    });
 </script>
+
 
 <style>
 
@@ -312,6 +491,19 @@ body {
   padding: 10px;
 }
 
+.online-status {
+  color: green;
+}
+
+.offline-status {
+  color: red;
+}
+
+.page-item.active a {
+  background-color: #A9A9A9;
+  color: #fff;
+}
+
 @media (max-width: 1100px) {
   .column {
     width: 100%;
@@ -352,7 +544,7 @@ body {
 
 table {
   border-collapse: collapse;
-  width: 95%;
+  width: 100%;
 }
 
 th, td {
@@ -373,4 +565,3 @@ li {
 }
 </style>
 </html>
-

--- a/yadacoin/core/config.py
+++ b/yadacoin/core/config.py
@@ -122,10 +122,11 @@ class Config:
         self.shares_required = config.get("shares_required", False)
         self.pool_payout = config.get("pool_payout", False)
         self.pool_take = config.get("pool_take", 0.01)
-        self.payout_frequency = config.get("payout_frequency", 6)
+        self.payout_frequency = config.get("payout_frequency", 300) # unused anymore
         self.max_miners = config.get("max_miners", 100)
         self.max_peers = config.get("max_peers", 20)
         self.pool_diff = config.get("pool_diff", 100000)
+        self.block_confirmation = config.get("block_confirmation", 6)
 
         self.restrict_graph_api = config.get("restrict_graph_api", False)
 
@@ -145,7 +146,7 @@ class Config:
         self.block_queue_processor_wait = config.get("block_queue_processor_wait", 10)
         self.block_checker_wait = config.get("block_checker_wait", 1)
         self.message_sender_wait = config.get("message_sender_wait", 10)
-        self.pool_payer_wait = config.get("pool_payer_wait", 120)
+        self.pool_payer_wait = config.get("pool_payer_wait", 1800)
         self.cache_validator_wait = config.get("cache_validator_wait", 30)
         self.mempool_cleaner_wait = config.get("mempool_cleaner_wait", 1200)
         self.nonce_processor_wait = config.get("nonce_processor_wait", 1)
@@ -327,7 +328,8 @@ class Config:
                 "shares_required": False,
                 "pool_payout": False,
                 "pool_take": 0.01,
-                "payout_frequency": 6,
+                "pool_payer_wait": 1800,
+                "block_confirmation": 6,
                 "max_miners": 100,
                 "max_peers": 20,
                 "pool_diff": 100000,
@@ -392,10 +394,11 @@ class Config:
         cls.shares_required = config.get("shares_required", False)
         cls.pool_payout = config.get("pool_payout", False)
         cls.pool_take = config.get("pool_take", 0.01)
-        cls.payout_frequency = config.get("payout_frequency", 6)
+        cls.payout_frequency = config.get("payout_frequency", 300) # unused anymore
         cls.max_miners = config.get("max_miners", 100)
         cls.max_peers = config.get("max_peers", 20)
         cls.pool_diff = config.get("pool_diff", 100000)
+        cls.block_confirmation = config.get("block_confirmation", 6)
 
         cls.restrict_graph_api = config.get("restrict_graph_api", False)
 
@@ -418,7 +421,7 @@ class Config:
         cls.block_queue_processor_wait = config.get("block_queue_processor_wait", 10)
         cls.block_checker_wait = config.get("block_checker_wait", 1)
         cls.message_sender_wait = config.get("message_sender_wait", 10)
-        cls.pool_payer_wait = config.get("pool_payer_wait", 120)
+        cls.pool_payer_wait = config.get("pool_payer_wait", 1800)
         cls.cache_validator_wait = config.get("cache_validator_wait", 30)
         cls.mempool_cleaner_wait = config.get("mempool_cleaner_wait", 1200)
         cls.nonce_processor_wait = config.get("nonce_processor_wait", 1)

--- a/yadacoin/core/health.py
+++ b/yadacoin/core/health.py
@@ -174,6 +174,11 @@ class NonceProcessorHealth(HealthItem):
 
 
 class PoolPayerHealth(HealthItem):
+    def __init__(self):
+        super().__init__()
+        self.config = yadacoin.core.config.Config()
+        self.timeout = self.config.pool_payer_wait + 10
+
     async def check_health(self):
         if not self.config.pp:
             return self.report_status(True, ignore=True)

--- a/yadacoin/core/health.py
+++ b/yadacoin/core/health.py
@@ -176,7 +176,7 @@ class NonceProcessorHealth(HealthItem):
 class PoolPayerHealth(HealthItem):
     def __init__(self):
         super().__init__()
-        self.config = yadacoin.core.config.Config()
+        self.config = Config()
         self.timeout = self.config.pool_payer_wait + 10
 
     async def check_health(self):

--- a/yadacoin/http/pool.py
+++ b/yadacoin/http/pool.py
@@ -2,25 +2,116 @@
 Handlers required by the pool operations
 """
 
+import time
 
 from yadacoin.http.base import BaseHandler
 
-
-class PoolSharesHandler(BaseHandler):
+class MinerStatsHandler(BaseHandler):
     async def get(self):
         address = self.get_query_argument("address")
-        query = {"address": address}
-        if "." not in address:
-            query = {
-                "$or": [
-                    {"address": address},
-                    {"address_only": address},
-                ]
-            }
-        total_share = await self.config.mongo.async_db.shares.count_documents(query)
-        total_hash = total_share * self.config.pool_diff
-        self.render_as_json({"total_hash": int(total_hash)})
+        query = {
+            "$or": [
+                {"address": address},
+                {"address_only": address},
+                {"address": {"$regex": f"^{address}\..*"}}
+            ]
+        }
 
+        miner_hashrate_seconds = 1200
+        hashrate_query = {"time": {"$gt": time.time() - miner_hashrate_seconds}}
+        
+        if "." in address:
+            hashrate_query["address"] = address
+        else:
+            hashrate_query["$or"] = [
+                {"address": address},
+                {"address_only": address},
+            ]
+
+        hashrate_cursor = self.config.mongo.async_db.shares.aggregate([
+            {"$match": hashrate_query},
+            {"$group": {
+                "_id": {"address": "$address", "worker": {"$ifNull": [{"$arrayElemAt": [{"$split": ["$address", "."]}, 1]}, "No worker"]}},
+                "number_of_shares": {"$sum": 1}
+            }}
+        ])
+
+        worker_hashrate = {}
+        total_hashrate = 0
+        total_share = 0
+
+        async for doc in hashrate_cursor:
+            worker_name = doc["_id"]["worker"]
+            number_of_shares = doc["number_of_shares"]
+
+            worker_hashrate_individual = number_of_shares * self.config.pool_diff // miner_hashrate_seconds
+            total_hashrate += worker_hashrate_individual
+
+            if worker_name not in worker_hashrate:
+                worker_hashrate[worker_name] = {
+                    "worker_hashrate": 0,
+                    "worker_share": 0
+                }
+
+            worker_hashrate[worker_name]["worker_hashrate"] += worker_hashrate_individual
+
+        shares_query = {
+            "$or": [
+                {"address": address},
+                {"address_only": address},
+                {"address": {"$regex": f"^{address}\..*"}}
+            ]
+        }
+
+        shares_cursor = self.config.mongo.async_db.shares.aggregate([
+            {"$match": shares_query},
+            {"$group": {
+                "_id": {"address": "$address", "worker": {"$ifNull": ["$worker", ""]}},
+                "total_share": {"$sum": 1},
+                "total_hash": {"$sum": {"$multiply": ["$difficulty", "$height"]}}
+            }}
+        ])
+
+        worker_shares = {}
+
+        async for doc in shares_cursor:
+            worker_name = doc["_id"]["worker"] if doc["_id"]["worker"] else "No worker"
+
+            if "." in doc["_id"]["address"]:
+                worker_name = doc["_id"]["address"].split(".")[-1]
+
+            if worker_name not in worker_shares:
+                worker_shares[worker_name] = {
+                    "worker_share": 0,
+                    "worker_hash": 0
+                }
+
+            worker_shares[worker_name]["worker_share"] += doc["total_share"]
+            worker_shares[worker_name]["worker_hash"] += doc["total_share"] * self.config.pool_diff
+            total_share += doc["total_share"]
+
+        miner_stats = []
+        for worker_name in set(worker_hashrate.keys()) | set(worker_shares.keys()):
+            worker_hashrate_val = worker_hashrate.get(worker_name, {}).get("worker_hashrate", 0)
+            worker_share_val = worker_shares.get(worker_name, {}).get("worker_share", 0)
+            worker_hash_val = worker_shares.get(worker_name, {}).get("worker_hash", 0)
+            status = "Offline" if worker_hashrate_val == 0 else "Online"
+
+            stats = {
+                "worker_name": worker_name,
+                "worker_hashrate": worker_hashrate_val,
+                "worker_share": worker_share_val,
+                "worker_hash": worker_hash_val,
+                "status": status
+            }
+            miner_stats.append(stats)
+
+        self.render_as_json({
+            "miner_stats": miner_stats,
+            "total_hashrate": int(total_hashrate),
+            "total_share": int(total_share),
+            "total_hash": int(total_share * self.config.pool_diff)
+        })
 
 class PoolPayoutsHandler(BaseHandler):
     async def get(self):
@@ -42,46 +133,6 @@ class PoolPayoutsHandler(BaseHandler):
                 out.append(result)
         self.render_as_json({"results": out})
 
-
-class PoolHashRateHandler(BaseHandler):
-    async def get(self):
-        address = self.get_query_argument("address")
-        query = {"address": address}
-        if "." not in address:
-            query = {
-                "$or": [
-                    {"address": address},
-                    {"address_only": address},
-                ]
-            }
-        last_share = await self.config.mongo.async_db.shares.find_one(
-            query, {"_id": 0}, sort=[("time", -1)]
-        )
-        if not last_share:
-            return self.render_as_json({"result": 0})
-        miner_hashrate_seconds = (
-            self.config.miner_hashrate_seconds
-            if hasattr(self.config, "miner_hashrate_seconds")
-            else 1200
-        )
-
-        query = {"time": {"$gt": last_share["time"] - miner_hashrate_seconds}}
-        if "." in address:
-            query["address"] = address
-        else:
-            query["$or"] = [
-                {"address": address},
-                {"address_only": address},
-            ]
-        number_of_shares = await self.config.mongo.async_db.shares.count_documents(
-            query
-        )
-        miner_hashrate = (
-            number_of_shares * self.config.pool_diff
-        ) / miner_hashrate_seconds
-        self.render_as_json({"miner_hashrate": int(miner_hashrate)})
-
-
 class PoolScanMissedPayoutsHandler(BaseHandler):
     async def get(self):
         start_index = self.get_query_argument("start_index")
@@ -90,8 +141,7 @@ class PoolScanMissedPayoutsHandler(BaseHandler):
 
 
 POOL_HANDLERS = [
-    (r"/shares-for-address", PoolSharesHandler),
+    (r"/miner-stats-for-address", MinerStatsHandler),
     (r"/payouts-for-address", PoolPayoutsHandler),
-    (r"/hashrate-for-address", PoolHashRateHandler),
     (r"/scan-missed-payouts", PoolScanMissedPayoutsHandler),
 ]


### PR DESCRIPTION
  -  pool pays out at specified time intervals
  - I added block confirmation before withdrawal
  -  possibility to set a 0% fee
  -  improved block reward after adding a masternode
  -  improved block reward display in the block table
  -  added hashrate monitoring for workers after selecting the main miner address
  -  payment statistics and conversion to $ / BTC (based on Safetrade API)
  -  I added the block number for which you receive the payment to the payment table
  - added pagination for the payout table
Tested as much as I can, it is best to put the update on one pool at the beginning and check it thoroughly