### PR TITLE
moving Market to a separate header

### DIFF
--- a/plugins/yadacoinpool/handlers.py
+++ b/plugins/yadacoinpool/handlers.py
@@ -3,11 +3,13 @@ import time
 
 import requests
 from tornado.web import StaticFileHandler
+from cachetools import TTLCache
 
 from yadacoin import version
 from yadacoin.core.chain import CHAIN
 from yadacoin.http.base import BaseHandler
 
+cache = TTLCache(maxsize=1, ttl=3600)
 
 class BaseWebHandler(BaseHandler):
     async def prepare(self):
@@ -29,30 +31,37 @@ class PoolStatsInterfaceHandler(BaseWebHandler):
             mixpanel="pool stats page",
         )
 
+class MarketInfoHandler(BaseWebHandler):
+    async def get(self):
+        market_data = cache.get("market_data")
+
+        if market_data is None:
+            market_data = await self.fetch_market_data()
+            cache["market_data"] = market_data
+
+        self.render_as_json(market_data)
+
+    async def fetch_market_data(self):
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
+        }
+        response = requests.get("https://safe.trade/api/v2/peatio/public/markets/tickers", headers=headers)
+
+        if response.status_code == 200:
+            market_data = {
+                "last_btc": float(response.json()["ydabtc"]["ticker"]["last"]),
+                "last_usdt": float(response.json()["ydausdt"]["ticker"]["last"])
+            }
+        else:
+            market_data = {
+                "last_btc": 0,
+                "last_usdt": 0
+            }
+        
+        return market_data
 
 class PoolInfoHandler(BaseWebHandler):
     async def get(self):
-        def get_ticker():
-            headers = {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
-            }
-            return requests.get(
-                "https://safe.trade/api/v2/peatio/public/markets/tickers",
-                headers=headers,
-            )
-
-        try:
-            if not hasattr(self.config, "ticker"):
-                self.config.ticker = get_ticker()
-                self.config.last_update = time.time()
-            if (time.time() - self.config.last_update) > (600 * 6):
-                self.config.ticker = get_ticker()
-                self.config.last_update = time.time()
-            last_btc = float(self.config.ticker.json()["ydabtc"]["ticker"]["last"])
-            last_usdt = float(self.config.ticker.json()["ydausdt"]["ticker"]["last"])
-        except:
-            last_btc = 0
-            last_usdt = 0
         await self.config.LatestBlock.block_checker()
         pool_public_key = (
             self.config.pool_public_key
@@ -198,7 +207,6 @@ class PoolInfoHandler(BaseWebHandler):
                     "current_hashes_per_second": network_hash_rate,
                     "difficulty": net_difficulty,
                 },
-                "market": {"last_btc": last_btc, "last_usdt": last_usdt},
                 "coin": {
                     "algo": "randomx YDA",
                     "circulating": CHAIN.get_circulating_supply(
@@ -211,6 +219,7 @@ class PoolInfoHandler(BaseWebHandler):
 
 
 HANDLERS = [
+    (r"/market-info", MarketInfoHandler),
     (r"/pool-info", PoolInfoHandler),
     (r"/", PoolStatsInterfaceHandler),
     (

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ dnspython
 networkutil
 setuptools_rust
 docker
+cachetools


### PR DESCRIPTION
this will reduce the time of calling /pool-info by about 500ms, we are not using it yet. I moved it because it will be used :)

2023-10-21 17:47:37,357 INFO 200 GET /market-info (127.0.0.1) 340.43ms
2023-10-21 17:47:46,662 INFO 304 GET /market-info (127.0.0.1) 0.66ms
2023-10-21 17:47:47,214 INFO 304 GET /market-info (127.0.0.1) 0.95ms
2023-10-21 17:47:47,653 INFO 304 GET /market-info (127.0.0.1) 0.82ms
2023-10-21 17:47:48,047 INFO 304 GET /market-info (127.0.0.1) 0.82ms