### PR TITLE
Update docker-compose.yml to lock mongodb port to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   mongodb:
     image: mongo:latest
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     volumes:
       - mongodb_data:/data/db
     command: --wiredTigerCacheSizeGB .25


### PR DESCRIPTION
docker add to iptables automatically if you don't limit the IP on the exposed port. added localhost(127.0.0.1) to avoid this.  if moggodb port is opened to the internet in VPS installation, there is bot attacking the server and delete all blocks data.