### PR TITLE
Fix connection handling and remove Unicode icons from logs

### DIFF
--- a/yadacoin/tcpsocket/base.py
+++ b/yadacoin/tcpsocket/base.py
@@ -255,7 +255,7 @@ class RPCSocketServer(TCPServer, BaseRPC):
         """
         stream.last_activity = int(time.time())
         self.config.health.tcp_server.last_activity = time.time()
-        self.config.app_log.info(f"✅ KeepAlive received from {stream.peer.host}. Connection is active.")
+        self.config.app_log.info(f"KeepAlive received from {stream.peer.host}. Connection is active.")
 
         await self.write_result(stream, "keepalive", {"ok": True}, body["id"])
 
@@ -495,12 +495,16 @@ class RPCSocketClient(TCPClient):
         while True:
             await asyncio.sleep(90)
 
+            if stream.closed():
+                self.config.app_log.warning(f"Stream to {stream.peer.host} is closed. Stopping KeepAlive.")
+                break
+
             try:
-                self.config.app_log.info(f"📡 Sending KeepAlive to {stream.peer.host}")
+                self.config.app_log.info(f"Sending KeepAlive to {stream.peer.host}")
                 await self.write_params(stream, "keepalive", {"timestamp": int(time.time())})
 
             except Exception as e:
-                self.config.app_log.warning(f"⚠️ Failed to send KeepAlive to {stream.peer.host}: {e}")
+                self.config.app_log.warning(f"Failed to send KeepAlive to {stream.peer.host}: {e}")
                 break
 
     async def remove_peer(self, stream, close=True, reason=None):


### PR DESCRIPTION
### This PR addresses two key issues:

**1. Properly closing streams on disconnection:**

- Ensures that disconnected streams are removed correctly to prevent lingering connections.
- Resolves issues where KeepAlive tasks continued running after the stream had already been closed.

**2. Removing Unicode icons from logs:**

- Some users running YadaCoin in Windows environments encountered encoding errors due to Unicode log symbols.
- Replaced symbols like ✅ and ⚠️ with plain text to prevent UnicodeEncodeError in log outputs.
- Ensures compatibility across all environments without breaking log readability.