### PR TITLE
Migrate transaction confirmation tracking to MongoDB

### DIFF
--- a/yadacoin/app.py
+++ b/yadacoin/app.py
@@ -784,7 +784,7 @@ class NodeApplication(Application):
             self.config.app_log.error(format_exc())
 
     async def background_mempool_cleaner(self):
-        """Responsible for removing failed transactions from the mempool"""
+        """Responsible for removing failed transactions from the mempool and old transaction confirmations"""
 
         self.config.app_log.debug("background_mempool_cleaner")
         if not hasattr(self.config, "background_mempool_cleaner"):
@@ -795,6 +795,7 @@ class NodeApplication(Application):
         self.config.background_mempool_cleaner.busy = True
         try:
             await self.config.TU.clean_mempool(self.config)
+            await self.config.TU.clean_txn_tracking(self.config)
             self.config.health.mempool_cleaner.last_activity = int(time())
         except Exception:
             self.config.app_log.error(format_exc())
@@ -813,7 +814,7 @@ class NodeApplication(Application):
         self.config.background_mempool_sender.busy = True
         try:
             await self.config.TU.rebroadcast_mempool(
-                self.config, NodeRPC.confirmed_peers, include_zero=True
+                self.config, include_zero=True
             )
         except Exception:
             self.config.app_log.error(format_exc())

--- a/yadacoin/core/transactionutils.py
+++ b/yadacoin/core/transactionutils.py
@@ -216,40 +216,74 @@ class TU(object):  # Transaction Utilities
         config.last_mempool_clean = time.time()
 
     @classmethod
-    async def rebroadcast_mempool(
-        cls, config, confirmed_peers=None, include_zero=False
-    ):
+    async def clean_txn_tracking(cls, config):
+        """
+        Removes old transaction confirmations from `txn_tracking` that are older than 24 hours.
+
+        - Ensures that peers are not storing unnecessary old transaction confirmations.
+        - Runs after `clean_mempool` to synchronize data cleanup.
+        - If all transactions under a peer (`rid`) are too old, the entry is deleted entirely.
+        """
+
+        cutoff_time = int(time.time()) - 60 * 60 * 24
+
+        async for doc in config.mongo.async_db.txn_tracking.find():
+            updated_transactions = {
+                txn_id: timestamp for txn_id, timestamp in doc["transactions"].items() if timestamp > cutoff_time
+            }
+
+            if updated_transactions:
+                await config.mongo.async_db.txn_tracking.update_one(
+                    {"rid": doc["rid"]},
+                    {"$set": {"transactions": updated_transactions}}
+                )
+            else:
+                await config.mongo.async_db.txn_tracking.delete_one({"rid": doc["rid"]})
+
+        config.app_log.info(f"[CLEANER] Removed old transaction confirmations.")
+
+    @classmethod
+    async def rebroadcast_mempool(cls, config, include_zero=False):
+        """
+        Rebroadcasts transactions from the mempool to peers who have not yet confirmed them.
+
+        - Runs every 3 minutes to ensure new peers receive transactions.
+        - Uses `txn_tracking` in MongoDB to avoid sending transactions to peers who already confirmed them.
+        - Can include zero-value transactions if `include_zero=True`.
+
+        This ensures efficient transaction propagation while minimizing redundant data transfer.
+        """
+
         from yadacoin.core.transaction import Transaction
 
         query = {"outputs.value": {"$gt": 0}}
         if include_zero:
             query = {}
 
-        if confirmed_peers is None:
-            confirmed_peers = []
-
         async for txn in config.mongo.async_db.miner_transactions.find(query):
             x = Transaction.from_dict(txn)
+
+            confirmed_peers = await config.mongo.async_db.txn_tracking.find(
+                {f"transactions.{x.transaction_signature}": {"$exists": True}}
+            ).to_list(length=None)
+
+            confirmed_rids = {peer["rid"] for peer in confirmed_peers}
+
             async for peer_stream in config.peer.get_sync_peers():
-                if (
-                    peer_stream.peer.rid,
-                    "newtxn",
-                    x.transaction_signature,
-                ) in confirmed_peers:
-                    config.app_log.debug(
-                        f"Skipping peer {peer_stream.peer.rid} in rebroadcast_mempool as it has already confirmed the transaction."
-                    )
+                if peer_stream.peer.rid in confirmed_rids:
+                    config.app_log.info(f"Skipping {peer_stream.peer.rid} - already confirmed.")
                     continue
 
                 await config.nodeShared.write_params(
                     peer_stream, "newtxn", {"transaction": x.to_dict()}
                 )
+
                 if peer_stream.peer.protocol_version > 1:
                     config.nodeClient.retry_messages[
                         (peer_stream.peer.rid, "newtxn", x.transaction_signature)
                     ] = {"transaction": x.to_dict()}
+                
                 await asyncio.sleep(1)
-        return
 
     @classmethod
     async def rebroadcast_failed(cls, config, id):

--- a/yadacoin/tcpsocket/base.py
+++ b/yadacoin/tcpsocket/base.py
@@ -88,7 +88,7 @@ class BaseRPC:
 
         except asyncio.TimeoutError:
             self.config.app_log.warning(
-                f"⏳ Timeout! Stream {peer_host} is unresponsive. Removing peer..."
+                f"Timeout! Stream {peer_host} is unresponsive. Removing peer..."
             )
             await self.remove_peer(stream)
             return

--- a/yadacoin/tcpsocket/node.py
+++ b/yadacoin/tcpsocket/node.py
@@ -53,10 +53,9 @@ class NodeServerDisconnectTracker:
 
 class NodeServerNewTxnTracker:
     by_host = {}
-    by_txn_id = {}
 
     def to_dict(self):
-        return {"by_host": self.by_host, "by_txn_id": self.by_txn_id}
+        return {"by_host": self.by_host}
 
 
 class NodeClientDisconnectTracker:
@@ -69,10 +68,9 @@ class NodeClientDisconnectTracker:
 
 class NodeClientNewTxnTracker:
     by_host = {}
-    by_txn_id = {}
 
     def to_dict(self):
-        return {"by_host": self.by_host, "by_txn_id": self.by_txn_id}
+        return {"by_host": self.by_host}
 
 
 class NodeRPC(BaseRPC):
@@ -237,9 +235,6 @@ class NodeRPC(BaseRPC):
 
         self.newtxn_tracker.by_host[stream.peer.host] = (
             self.newtxn_tracker.by_host.get(stream.peer.host, 0) + 1
-        )
-        self.newtxn_tracker.by_txn_id[txn_id] = (
-            self.newtxn_tracker.by_txn_id.get(txn_id, 0) + 1
         )
 
         self.config.processing_queues.transaction_queue.add(

--- a/yadacoin/tcpsocket/node.py
+++ b/yadacoin/tcpsocket/node.py
@@ -77,7 +77,6 @@ class NodeClientNewTxnTracker:
 
 class NodeRPC(BaseRPC):
     retry_messages = {}
-    confirmed_peers = set()
 
     def __init__(self):
         super(NodeRPC, self).__init__()
@@ -157,6 +156,7 @@ class NodeRPC(BaseRPC):
         - Verifies if the transaction already exists in the mempool to prevent duplicates.
         - Checks for double-spending by ensuring none of the transaction inputs have been used before.
         - Tracks incoming transactions per host and transaction ID for monitoring.
+        - Immediately stores the sender in `txn_tracking` to prevent re-sending the transaction to them.
         - Adds the transaction to the processing queue if all validations pass.
         - If the transaction involves a known WebSocket user, forwards it to the appropriate peer.
 
@@ -189,6 +189,17 @@ class NodeRPC(BaseRPC):
             await self.write_result(
                 stream, "newtxn_confirmed", {"transaction": txn.to_dict()}, body["id"]
             )
+
+        await self.config.mongo.async_db.txn_tracking.update_one(
+            {"rid": stream.peer.rid},
+            {
+                "$set": {
+                    "host": stream.peer.host,
+                    f"transactions.{txn_id}": int(time.time())
+                }
+            },
+            upsert=True
+        )
 
         existing_txn = await self.config.mongo.async_db.miner_transactions.find_one({"id": txn_id})
         if existing_txn:
@@ -274,6 +285,14 @@ class NodeRPC(BaseRPC):
             item = self.config.processing_queues.transaction_queue.pop()
 
     async def process_transaction_queue_item(self, item):
+        """
+        Processes each transaction from the queue, verifies it, and propagates it to unconfirmed peers.
+
+        - Runs transaction verification with the latest validation rules.
+        - Stores the transaction in `miner_transactions` if valid.
+        - Checks `txn_tracking` in MongoDB to avoid sending to already confirmed peers.
+        - Sends transaction to inbound and outbound peers who have not yet confirmed it.
+        """
         txn = item.transaction
         stream = item.stream
 
@@ -315,51 +334,35 @@ class NodeRPC(BaseRPC):
             {"id": txn.transaction_signature}, txn.to_dict(), upsert=True
         )
 
+        confirmed_peers = await self.config.mongo.async_db.txn_tracking.find(
+            {f"transactions.{txn.transaction_signature}": {"$exists": True}}
+        ).to_list(length=None)
+
+        confirmed_rids = {peer["rid"] for peer in confirmed_peers}
+
         async def make_gen(streams):
             for stream in streams:
                 yield stream
 
         async for peer_stream in self.config.peer.get_inbound_streams():
-            if peer_stream.peer.rid == stream.peer.rid:
-                self.config.app_log.debug(
-                    f"Skipping peer {stream.peer.rid} in inbound stream as it is the sender."
-                )
-                continue
-            elif (
-                stream.peer.rid,
-                "newtxn",
-                txn.transaction_signature,
-            ) in self.confirmed_peers:
-                self.config.app_log.debug(
-                    f"Skipping peer {stream.peer.rid} in inbound stream as it has already confirmed the transaction."
-                )
+            if peer_stream.peer.rid in confirmed_rids:
+                self.config.app_log.debug(f"Skipping {peer_stream.peer.rid} - already confirmed.")
                 continue
             if peer_stream.peer.protocol_version > 1:
-                self.retry_messages[
-                    (peer_stream.peer.rid, "newtxn", txn.transaction_signature)
-                ] = {"transaction": txn.to_dict()}
+                self.retry_messages[(peer_stream.peer.rid, "newtxn", txn.transaction_signature)] = {
+                    "transaction": txn.to_dict()
+                }
 
         async for peer_stream in make_gen(
             await self.config.peer.get_outbound_streams()
         ):
-            if peer_stream.peer.rid == stream.peer.rid:
-                self.config.app_log.debug(
-                    f"Skipping peer {stream.peer.rid} in outbound stream as it is the sender."
-                )
-                continue
-            elif (
-                stream.peer.rid,
-                "newtxn",
-                txn.transaction_signature,
-            ) in self.confirmed_peers:
-                self.config.app_log.debug(
-                    f"Skipping peer {stream.peer.rid} in outbound stream as it has already confirmed the transaction."
-                )
+            if peer_stream.peer.rid in confirmed_rids:
+                self.config.app_log.debug(f"Skipping {peer_stream.peer.rid} - already confirmed.")
                 continue
             if peer_stream.peer.protocol_version > 1:
-                self.config.nodeClient.retry_messages[
-                    (peer_stream.peer.rid, "newtxn", txn.transaction_signature)
-                ] = {"transaction": txn.to_dict()}
+                self.config.nodeClient.retry_messages[(peer_stream.peer.rid, "newtxn", txn.transaction_signature)] = {
+                    "transaction": txn.to_dict()
+                }
 
     async def newtxn_confirmed(self, body, stream):
         """
@@ -391,7 +394,20 @@ class NodeRPC(BaseRPC):
         if retry_key in self.retry_messages:
             del self.retry_messages[retry_key]
 
-        self.confirmed_peers.add(retry_key)
+        await self.config.mongo.async_db.txn_tracking.update_one(
+            {"rid": stream.peer.rid},  
+            {
+                "$set": {
+                    "host": stream.peer.host,
+                    f"transactions.{txn_id}": int(time.time())
+                }
+            },
+            upsert=True
+        )
+
+        self.config.app_log.info(
+            f"[NEW_TXN_CONFIRM] Transaction {txn_id} confirmed by peer {stream.peer.rid}. Peer added to confirmed list."
+        )
 
     async def newblock(self, body, stream):
         """


### PR DESCRIPTION
This PR refactors the transaction confirmation tracking system, replacing the old in-memory set with a MongoDB-based approach.

### Key Changes:
- Transaction confirmations (`txn_id`) are now stored in the `txn_tracking` collection with a 24-hour retention.
- Eliminates the issue where mempool transactions were re-sent to peers after a node restart due to the loss of the in-memory confirmation set.
- Reduces memory usage, as the previous in-memory set would grow significantly when many transactions were processed.
- Ensures that peers do not receive duplicate mempool transactions they have already confirmed.

This update improves network efficiency and ensures proper transaction tracking across restarts.
