### PR TITLE
Optimize pool refresh & prevent redundant block validation

### DIFF
--- a/yadacoin/core/block.py
+++ b/yadacoin/core/block.py
@@ -125,6 +125,7 @@ class Block(object):
         "target",
         "special_target",
         "header",
+        "is_verified",
     )
 
     @classmethod
@@ -144,6 +145,7 @@ class Block(object):
         header="",
         target: int = 0,
         special_target: int = 0,
+        is_verified: bool = False
     ):
         self = cls()
         self.config = Config()
@@ -182,6 +184,7 @@ class Block(object):
             transaction = Transaction.ensure_instance(txn)
             transaction.coinbase = Block.is_coinbase(self, transaction)
             self.transactions.append(transaction)
+        self.is_verified = is_verified
 
         return self
 

--- a/yadacoin/core/processingqueue.py
+++ b/yadacoin/core/processingqueue.py
@@ -47,10 +47,11 @@ class ProcessingQueue:
 
 
 class BlockProcessingQueueItem:
-    def __init__(self, blockchain: Blockchain, stream=None, body=None):
+    def __init__(self, blockchain: Blockchain, stream=None, body=None, source="unknown"):
         self.blockchain = blockchain
         self.body = body or {}
         self.stream = stream
+        self.source = source
 
 
 class BlockProcessingQueue(ProcessingQueue):


### PR DESCRIPTION
This update optimizes pool performance by preventing unnecessary block refreshes and duplicate block validation.

**Fixes & Improvements:**

- Replaces is_synced() check with block source validation, ensuring refresh occurs only when necessary (newblock from peers or a mined block by the pool).
- Prevents double-mining on an already found block, reducing wasted miner resources.
- Avoids refresh deadlocks: Previously, synced or syncing states could occasionally block refreshes during normal operation, causing the pool to keep searching for an already found block.
- Added is_verified flag to avoid redundant block validation:
    - Previously, test_block() ran twice in integrate_blocks_with_existing_chain().
    - Now, blocks marked verified won’t be re-validated before insertion.
    - Reduces unnecessary computational overhead and improves sync speed.

**Result:**

- More accurate block updates
- Better miner efficiency
- No wasted hashing power
- Faster chain synchronization due to reduced duplicate block checks.